### PR TITLE
Fix the language parameter passed to uipcli

### DIFF
--- a/scripts/UiPathRunTest.ps1
+++ b/scripts/UiPathRunTest.ps1
@@ -257,7 +257,7 @@ if($out -ne ""){
     $ParamList.Add($out)
 }
 if($language -ne ""){
-    $ParamList.Add("-language")
+    $ParamList.Add("--language")
     $ParamList.Add($language)
 }
 if($traceLevel -ne ""){


### PR DESCRIPTION
The language switch of uipcli uses long option format with two dashes.